### PR TITLE
Fix for "azurerm_role_assignment" "disks_resource_group_role_assignment" when multiple clusters

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "2.57.0"
-      configuration_aliases = [ azurerm.hmcts-control, azurerm.acr, azurerm.global_acr  ]
+      source                = "hashicorp/azurerm"
+      version               = "2.57.0"
+      configuration_aliases = [azurerm.hmcts-control, azurerm.acr, azurerm.global_acr]
     }
   }
 }

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -36,3 +36,7 @@ variable "sku_tier" {
   default     = "Free"
   description = "Free or Paid (which includes the uptime SLA)"
 }
+
+variable "ptl_cluster" {
+  default = false
+}

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -144,7 +144,7 @@ data "azurerm_resource_group" "disks_resource_group" {
 }
 
 resource "azurerm_role_assignment" "disks_resource_group_role_assignment" {
-  count                = var.cluster_number == "00" ? 1 : 0
+  count                = var.ptl_cluster ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   scope                = data.azurerm_resource_group.disks_resource_group.id
   role_definition_name = "Virtual Machine Contributor"

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -140,7 +140,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
 }
 
 data "azurerm_resource_group" "disks_resource_group" {
-  name = "disks-${var.environment}-rg"
+  count = var.ptl_cluster ? 1 : 0
+  name  = "disks-${var.environment}-rg"
 }
 
 resource "azurerm_role_assignment" "disks_resource_group_role_assignment" {

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -46,7 +46,7 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
     min_count            = var.kubernetes_cluster_agent_min_count
     os_disk_type         = "Ephemeral"
     orchestrator_version = var.kubernetes_cluster_version
-    tags = var.tags
+    tags                 = var.tags
   }
 
   dns_prefix = format("k8s-%s-%s-%s",
@@ -136,7 +136,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
   node_taints           = each.value.node_taints
   orchestrator_version  = var.kubernetes_cluster_version
   vnet_subnet_id        = data.azurerm_subnet.aks.id
-  tags = var.tags
+  tags                  = var.tags
 }
 
 data "azurerm_resource_group" "disks_resource_group" {
@@ -144,6 +144,7 @@ data "azurerm_resource_group" "disks_resource_group" {
 }
 
 resource "azurerm_role_assignment" "disks_resource_group_role_assignment" {
+  count                = var.cluster_number == "00" ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   scope                = data.azurerm_resource_group.disks_resource_group.id
   role_definition_name = "Virtual Machine Contributor"

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -140,7 +140,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
 }
 
 data "azurerm_resource_group" "disks_resource_group" {
-  count = var.ptl_cluster ? 1 : 0
   name  = "disks-${var.environment}-rg"
 }
 


### PR DESCRIPTION
### Change description ###
Fix for "azurerm_role_assignment" "disks_resource_group_role_assignment" when multiple clusters
- sbox etc, we deploy 00/01
- Deploys fine when we select deploy_all
- If I delete sbox01, then redeploy sbox01
- I got an error to say the role_assignment exists
https://dev.azure.com/hmcts/CNP/_build/results?buildId=156667&view=logs&j=9529ead6-39ae-5319-1740-9d2035106bd6&t=82916ec7-6bfc-5be6-8e43-ad333d8f6c48&l=32 

This just creates "azurerm_role_assignment" "disks_resource_group_role_assignment" with cluster00 only. 
https://dev.azure.com/hmcts/CNP/_build/results?buildId=156679&view=logs&j=9529ead6-39ae-5319-1740-9d2035106bd6&t=89b2e481-5d95-5be1-d64b-e101e3d88784&l=475 

I believe this was initially implemented for Jenkins/PVC

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
