### PR TITLE
DTSPO-4676 - set default node pool to system and add taint.

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -40,3 +40,7 @@ variable "sku_tier" {
 variable "ptl_cluster" {
   default = false
 }
+
+variable "enable_user_system_nodepool_split" {
+  default = false
+}

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -35,8 +35,8 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
 
   sku_tier = var.sku_tier
   default_node_pool {
-    name                 = var.enable_user_system_nodepool_split == "true" ? "system" : "nodepool"
-    node_taints          = var.enable_user_system_nodepool_split == "true" ? ["CriticalAddonsOnly=true:NoSchedule"] : []
+    name                 = var.enable_user_system_nodepool_split == true ? "system" : "nodepool"
+    node_taints          = var.enable_user_system_nodepool_split == true ? ["CriticalAddonsOnly=true:NoSchedule"] : []
     vm_size              = var.kubernetes_cluster_agent_vm_size
     enable_auto_scaling  = var.kubernetes_cluster_enable_auto_scaling
     max_pods             = var.kubernetes_cluster_agent_max_pods

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -35,8 +35,8 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
 
   sku_tier = var.sku_tier
   default_node_pool {
-    name                 = var.project == "ss" ? "system" : "nodepool"
-    node_taints          = var.project == "ss" ? ["CriticalAddonsOnly=true:NoSchedule"] : []
+    name                 = var.enable_user_system_nodepool_split == "true" ? "system" : "nodepool"
+    node_taints          = var.enable_user_system_nodepool_split == "true" ? ["CriticalAddonsOnly=true:NoSchedule"] : []
     vm_size              = var.kubernetes_cluster_agent_vm_size
     enable_auto_scaling  = var.kubernetes_cluster_enable_auto_scaling
     max_pods             = var.kubernetes_cluster_agent_max_pods

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -35,7 +35,8 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
 
   sku_tier = var.sku_tier
   default_node_pool {
-    name                 = "nodepool"
+    name                 = "system"
+    node_taints          = ["CriticalAddonsOnly=true:NoSchedule"]
     vm_size              = var.kubernetes_cluster_agent_vm_size
     enable_auto_scaling  = var.kubernetes_cluster_enable_auto_scaling
     max_pods             = var.kubernetes_cluster_agent_max_pods

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -35,8 +35,8 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
 
   sku_tier = var.sku_tier
   default_node_pool {
-    name                 = "system"
-    node_taints          = ["CriticalAddonsOnly=true:NoSchedule"]
+    name                 = var.project == "ss" ? "system" : "nodepool"
+    node_taints          = var.project == "ss" ? ["CriticalAddonsOnly=true:NoSchedule"] : []
     vm_size              = var.kubernetes_cluster_agent_vm_size
     enable_auto_scaling  = var.kubernetes_cluster_enable_auto_scaling
     max_pods             = var.kubernetes_cluster_agent_max_pods


### PR DESCRIPTION
### Change description ###
- set default node pool name to system 
- added `CriticalAddonsOnly=true:NoSchedule` taint to make default pool the "system apps" node pool.
- tested a plan in sandbox and it looks good


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
