### PR TITLE
Downgrade AzureRM to 2.75

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "2.76.0"
+      version               = "2.75.0"
       configuration_aliases = [azurerm.hmcts-control, azurerm.acr, azurerm.global_acr]
     }
   }


### PR DESCRIPTION
### Change description ###
- Downgrading to 2.75 due to a bug in 2.76 🤦🏼 

When running an apply I received this error  `Error: Code="InvalidOSSKU" Message="OSSKU='Ubuntu' is invalid, details: Windows does not allow OSSKU selection`, where terraform defaults to an OSSKU of Ubuntu even if the type is windows.

Issue described here: https://github.com/hashicorp/terraform-provider-azurerm/issues/13312


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
