### PR TITLE
DSTPO-4675 system is the default node pool

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "2.76.0"
+      version               = "2.75.0"
       configuration_aliases = [azurerm.hmcts-control, azurerm.acr, azurerm.global_acr]
     }
   }

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -35,18 +35,19 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
 
   sku_tier = var.sku_tier
   default_node_pool {
-    name                 = var.enable_user_system_nodepool_split == true ? "linux" : "nodepool"
-    vm_size              = var.kubernetes_cluster_agent_vm_size
-    enable_auto_scaling  = var.kubernetes_cluster_enable_auto_scaling
-    max_pods             = var.kubernetes_cluster_agent_max_pods
-    os_disk_size_gb      = var.kubernetes_cluster_agent_os_disk_size
-    type                 = var.kubernetes_cluster_agent_type
-    vnet_subnet_id       = data.azurerm_subnet.aks.id
-    max_count            = var.kubernetes_cluster_agent_max_count
-    min_count            = var.kubernetes_cluster_agent_min_count
-    os_disk_type         = "Ephemeral"
-    orchestrator_version = var.kubernetes_cluster_version
-    tags                 = var.tags
+    name                         = var.enable_user_system_nodepool_split == true ? "system" : "nodepool"
+    only_critical_addons_enabled = var.enable_user_system_nodepool_split == true ? true : false
+    vm_size                      = var.kubernetes_cluster_agent_vm_size
+    enable_auto_scaling          = var.kubernetes_cluster_enable_auto_scaling
+    max_pods                     = var.kubernetes_cluster_agent_max_pods
+    os_disk_size_gb              = var.kubernetes_cluster_agent_os_disk_size
+    type                         = var.kubernetes_cluster_agent_type
+    vnet_subnet_id               = data.azurerm_subnet.aks.id
+    max_count                    = var.kubernetes_cluster_agent_max_count
+    min_count                    = var.kubernetes_cluster_agent_min_count
+    os_disk_type                 = "Ephemeral"
+    orchestrator_version         = var.kubernetes_cluster_version
+    tags                         = var.tags
   }
 
   dns_prefix = format("k8s-%s-%s-%s",
@@ -141,7 +142,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
 }
 
 data "azurerm_resource_group" "disks_resource_group" {
-  name  = "disks-${var.environment}-rg"
+  name = "disks-${var.environment}-rg"
 }
 
 resource "azurerm_role_assignment" "disks_resource_group_role_assignment" {


### PR DESCRIPTION
### Change description ###
Figured out the proper way of tainting the nodes using `only_critical_addons_enabled` instead of setting the taint using `taints`, this allows the default node to be a system node with the `CriticalAddonsOnly=true:NoSchedule` taint set.

Also downgrading AzureRM provider to 2.75 as there are issues with 2.76 setting ubuntu as the default ossku which breaks the windows node pool deployment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
