### PR TITLE
Upgrade azurerm provider to 2.77

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "2.75.0"
+      version               = "2.77.0"
       configuration_aliases = [azurerm.hmcts-control, azurerm.acr, azurerm.global_acr]
     }
   }


### PR DESCRIPTION
### Change description ###
- Updating to latest tf version as the bug with the ossku being set incorrectly for windows nodes has been fixed in 2.77


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
