### PR TITLE
DTSPO-5189 Only enable kube-audit-admin on prod

### DIFF
--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -188,7 +188,7 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 
   log {
     category = "kube-audit-admin"
-    enabled  = true
+    enabled  = var.environment == "prod" ? true : false
   }
 
   metric {


### PR DESCRIPTION
Reduce cost, this is a large amount of our ingress and it has never been used by anyone. Keep it in prod 'just in case'