### PR TITLE
disable containerInsights by default in aks module

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -53,3 +53,8 @@ variable "kubelet_uami_enabled" {
   default     = false
   description = "Feature toggle flag to enable/disable the use of our own managed identity"
 }
+
+variable "oms_agent" {
+  default     = false
+  description = "To toggle if oms_agent is required. This is for ContainerInsights"
+}

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -54,7 +54,7 @@ variable "kubelet_uami_enabled" {
   description = "Feature toggle flag to enable/disable the use of our own managed identity"
 }
 
-variable "oms_agent" {
+variable "oms_agent_enabled" {
   default     = false
   description = "To toggle if oms_agent is required. This is for ContainerInsights"
 }

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -55,6 +55,6 @@ variable "kubelet_uami_enabled" {
 }
 
 variable "oms_agent_enabled" {
-  default     = true
+  default     = false
   description = "To toggle if oms_agent is required. This is for ContainerInsights"
 }

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -55,6 +55,6 @@ variable "kubelet_uami_enabled" {
 }
 
 variable "oms_agent_enabled" {
-  default     = false
+  default     = true
   description = "To toggle if oms_agent is required. This is for ContainerInsights"
 }

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -78,10 +78,12 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
     }
   }
 
-  oms_agent {
-    log_analytics_workspace_id = var.log_workspace_id
+  dynamic "oms_agent" {
+    for_each = var.oms_agent_enabled != false ? [1] : []
+    content {
+      log_analytics_workspace_id = var.log_workspace_id
+    }
   }
-
 
   kubernetes_version = var.kubernetes_cluster_version
 


### PR DESCRIPTION
### Change description ###
disable containerInsights by default in aks module
- Plan with disabling & enabled, looks fine.
- Once approved, will merge and apply to SDS/CFT repos to enable for Prod etc

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
