### PR TITLE
DTSPO-10279 -  auto channel updates precondition message

### DIFF
--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -121,6 +121,11 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
     ignore_changes = [
       windows_profile,
     ]
+    precondition {
+      // Error if enable_automatic_channel_upgrade_patch is true and the Kubernetes version includes the patch version
+      condition     = var.enable_automatic_channel_upgrade_patch != true || can(regex("^1\\.\\d\\d$", var.kubernetes_cluster_version))
+      error_message = "When automatic upgrades are enabled, kubernetes_cluster_version must only include major and minor versions, not the patch version e.g. 1.18 or 1.25"
+    }
   }
 
   automatic_channel_upgrade = var.enable_automatic_channel_upgrade_patch == true ? "patch" : null


### PR DESCRIPTION
### Change description ###
Trying out a precondition to make it clear for anyone else that enables automatic updates.

If someone enables automatic updates but doesn't remove the patch version from the kubernetes_cluster_version var, they'll get a nice error message like below instead of potentially not understanding why the cluster isn't being upgraded.

```terraform
│ Error: Resource precondition failed
│ 
│   on ../../../../tf_modules/aks-module-kubernetes/12-kubernetes-cluster.tf line 126, in resource "azurerm_kubernetes_cluster" "kubernetes_cluster":
│  126:       condition     = var.enable_automatic_channel_upgrade_patch != true || can(regex("^1\\.\\d\\d$", var.kubernetes_cluster_version))
│     ├────────────────
│     │ var.enable_automatic_channel_upgrade_patch is true
│     │ var.kubernetes_cluster_version is "1.22.6"
│ 
│ When automatic upgrades are enabled, kubernetes_cluster_version must only include major and minor versions, not the patch version e.g. 1.18 or 1.25
╵

```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
