### PR TITLE
Toggle - Increase max surge when upgrading

### DIFF
--- a/10-kubernetes-inputs.tf
+++ b/10-kubernetes-inputs.tf
@@ -81,3 +81,8 @@ variable "enable_automatic_channel_upgrade_patch" {
   description = "When set to true automatic patch updates will be enabled on the cluster"
   default     = false
 }
+
+variable "enable_recommended_max_surge" {
+  description = "Set the max surge when upgrading to 33% rather than the default 1"
+  default     = false
+}

--- a/10-kubernetes-inputs.tf
+++ b/10-kubernetes-inputs.tf
@@ -82,7 +82,7 @@ variable "enable_automatic_channel_upgrade_patch" {
   default     = false
 }
 
-variable "enable_recommended_max_surge" {
-  description = "Set the max surge when upgrading to 33% rather than the default 1"
-  default     = false
+variable "upgrade_max_surge" {
+  description = "Set the max surge when upgrading"
+  default     = "33%"
 }

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -161,7 +161,7 @@ resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
-  for_each = { for np in var.additional_node_pools : np.name => np }
+  for_each = {for np in var.additional_node_pools : np.name => np}
 
   name                  = each.value.name
   kubernetes_cluster_id = azurerm_kubernetes_cluster.kubernetes_cluster.id
@@ -179,12 +179,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
   tags                  = var.tags
   zones                 = var.availability_zones
 
-  dynamic "upgrade_settings" {
-    for_each = var.enable_recommended_max_surge == true ? [1] : []
-
-    content {
-      max_surge = "33%"
-    }
+  upgrade_settings {
+    max_surge = var.upgrade_max_surge
   }
 }
 

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -161,7 +161,7 @@ resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
-  for_each = {for np in var.additional_node_pools : np.name => np}
+  for_each = { for np in var.additional_node_pools : np.name => np }
 
   name                  = each.value.name
   kubernetes_cluster_id = azurerm_kubernetes_cluster.kubernetes_cluster.id

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -171,6 +171,14 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
   vnet_subnet_id        = data.azurerm_subnet.aks.id
   tags                  = var.tags
   zones                 = var.availability_zones
+
+  dynamic "upgrade_settings" {
+    for_each = var.enable_recommended_max_surge == true ? [1] : []
+
+    content {
+      max_surge = "33%"
+    }
+  }
 }
 
 data "azurerm_resource_group" "disks_resource_group" {


### PR DESCRIPTION
### Change description ###
Adding toggle to Increase the max surge setting to 33% as per Microsofts recommendation. 

https://learn.microsoft.com/en-gb/azure/aks/upgrade-cluster?tabs=azure-cli#customize-node-surge-upgrade:~:text=The%20max%20surge%20setting%20on%20a%20node%20pool%20is%20persistent.%20Subsequent%20Kubernetes%20upgrades%20or%20node%20version%20upgrades%20will%20use%20this%20setting.%20You%20may%20change%20the%20max%20surge%20value%20for%20your%20node%20pools%20at%20any%20time.%20For%20production%20node%20pools%2C%20we%20recommend%20a%20max%2Dsurge%20setting%20of%2033%25.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
