### PR TITLE
DTSPO-10591 workload identity webhook

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -44,6 +44,7 @@ variable "ptl_cluster" {
 variable "enable_user_system_nodepool_split" {
   default = false
 }
+
 variable "availability_zones" {
   type    = list(any)
   default = []
@@ -62,4 +63,8 @@ variable "oms_agent_enabled" {
 variable "csi_driver_enabled" {
   default     = false
   description = "A toggle to deploy the csi driver as an add-on"
+}
+
+variable "workload_identity_enabled" {
+  default = false
 }

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -42,7 +42,6 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
 
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
-  
 
   sku_tier = var.sku_tier
   default_node_pool {

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -41,7 +41,7 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
   )
 
   oidc_issuer_enabled       = true
-  workload_identity_enabled = true
+  workload_identity_enabled = var.workload_identity_enabled
 
   sku_tier = var.sku_tier
   default_node_pool {

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -40,7 +40,9 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
     var.service_shortname
   )
 
-  oidc_issuer_enabled = true
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+  
 
   sku_tier = var.sku_tier
   default_node_pool {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-10591

### Change description ###

Adds flag to enable workload identity webhook on clusters

Tested here - https://dev.azure.com/hmcts/CNP/_build/results?buildId=285760&view=logs&j=9529ead6-39ae-5319-1740-9d2035106bd6&t=89b2e481-5d95-5be1-d64b-e101e3d88784

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
