### PR TITLE
Add permission for the AKS version checker

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -68,3 +68,8 @@ variable "csi_driver_enabled" {
 variable "workload_identity_enabled" {
   default = false
 }
+
+variable "aks_version_checker_principal_id" {
+  default = ""
+  description = "principal ID for the AKS version checker principal"
+}

--- a/update-checker-permissions.tf
+++ b/update-checker-permissions.tf
@@ -1,0 +1,7 @@
+resource "azurerm_role_assignment" "update_checker" {
+  count = var.aks_version_checker_principal_id == "" ? 0 : 1
+
+  principal_id         = var.aks_version_checker_principal_id
+  scope                = azurerm_kubernetes_cluster.kubernetes_cluster.id
+  role_definition_name = "Reader"
+}


### PR DESCRIPTION
So that we can remove https://github.com/hmcts/azure-github-federation-config/blob/ff3aeab4659e147a2cf76a6afde40dcc4f1fa3b8/app-registrations.yaml#L7-L17

as those will be deleted when the cluster is recreated