### PR TITLE
DTSPO-11630 - remove dependency on generated resource group

### DIFF
--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -164,6 +164,8 @@ resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
 #   scope                = data.azurerm_resource_group.node_resource_group.id
   scope                = "/subscriptions/${data.azurerm_subscription.subscription.subscription_id}/resourceGroups/${local.node_resource_group}"
   role_definition_name = "Virtual Machine Contributor"
+  
+  depends_on = azurerm_kubernetes_cluster.kubernetes_cluster
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -165,7 +165,9 @@ resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
   scope                = "/subscriptions/${data.azurerm_subscription.subscription.subscription_id}/resourceGroups/${local.node_resource_group}"
   role_definition_name = "Virtual Machine Contributor"
   
-  depends_on = azurerm_kubernetes_cluster.kubernetes_cluster
+  depends_on = [
+    azurerm_kubernetes_cluster.kubernetes_cluster
+  ]
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -155,13 +155,8 @@ resource "azurerm_role_assignment" "uami_rg_identity_operator" {
   count = var.kubelet_uami_enabled ? 0 : 1
 }
 
-# data "azurerm_resource_group" "node_resource_group" {
-#   name = azurerm_kubernetes_cluster.kubernetes_cluster.node_resource_group
-# }
-
 resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
   principal_id         = azurerm_kubernetes_cluster.kubernetes_cluster.kubelet_identity[0].object_id
-#   scope                = data.azurerm_resource_group.node_resource_group.id
   scope                = "/subscriptions/${data.azurerm_subscription.subscription.subscription_id}/resourceGroups/${local.node_resource_group}"
   role_definition_name = "Virtual Machine Contributor"
   

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -162,7 +162,7 @@ resource "azurerm_role_assignment" "uami_rg_identity_operator" {
 resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
   principal_id         = azurerm_kubernetes_cluster.kubernetes_cluster.kubelet_identity[0].object_id
 #   scope                = data.azurerm_resource_group.node_resource_group.id
-  scope                = "/subscriptions/${data.azurerm_subscription.subscription.subscription_id}/resourceGroups/${var.node_resource_group}"
+  scope                = "/subscriptions/${data.azurerm_subscription.subscription.subscription_id}/resourceGroups/${local.node_resource_group}"
   role_definition_name = "Virtual Machine Contributor"
 }
 

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -3,12 +3,7 @@
 #--------------------------------------------------------------
 
 locals {
-  node_resource_group = format("%s-%s-%s-%s-node-rg",
-    var.project,
-    var.environment,
-    var.cluster_number,
-    var.service_shortname
-  )
+  node_resource_group =  "${var.project}-${var.environment}-${var.cluster_number}-${var.service_shortname}-node-rg"
 }
 
 data "azurerm_resource_group" "genesis_rg" {

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -152,6 +152,11 @@ resource "azurerm_role_assignment" "uami_rg_identity_operator" {
 
 resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
   principal_id         = azurerm_kubernetes_cluster.kubernetes_cluster.kubelet_identity[0].object_id
+  
+  # https://github.com/hmcts/aks-module-kubernetes/pull/81
+  # Semi hard-coded scope to remove dependency on getting the ID for the node resource group from the attributes
+  # of the cluster resource causing role assignments to be recreated and sometimes having to be 
+  # recreated manually.
   scope                = "/subscriptions/${data.azurerm_subscription.subscription.subscription_id}/resourceGroups/${local.node_resource_group}"
   role_definition_name = "Virtual Machine Contributor"
   

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -162,7 +162,7 @@ resource "azurerm_role_assignment" "uami_rg_identity_operator" {
 resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
   principal_id         = azurerm_kubernetes_cluster.kubernetes_cluster.kubelet_identity[0].object_id
 #   scope                = data.azurerm_resource_group.node_resource_group.id
-  scope                = "/subscriptions/${var.subscription_id}/resourceGroups/${var.node_resource_group}"
+  scope                = "/subscriptions/${data.azurerm_subscription.subscription.subscription_id}/resourceGroups/${var.node_resource_group}"
   role_definition_name = "Virtual Machine Contributor"
 }
 


### PR DESCRIPTION
### Change description ###
This resolves [role assignments being removed](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=306065&view=logs&j=9529ead6-39ae-5319-1740-9d2035106bd6&t=89b2e481-5d95-5be1-d64b-e101e3d88784&l=633) when updating an AKS cluster.

The reason for the role assignment being deleted when a cluster gets updated is because of the dependency on getting the name of the Resource Group that is auto-generated when creating an AKS cluster from the attributes of the `azurerm_kubernetes_cluster` resource. 

Example plan output (truncated):
```terraform
  # module.kubernetes["00"].data.azurerm_resource_group.node_resource_group will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "azurerm_resource_group" "node_resource_group" {
      + id       = (known after apply)
      + location = (known after apply)
      + name     = "ss-sbox-00-aks-node-rg"
      + tags     = (known after apply)

      + timeouts {
          + read = (known after apply)
        }
    }

  # module.kubernetes["00"].azurerm_kubernetes_cluster.kubernetes_cluster will be updated in-place
  ~ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
        id                                  = "/subscriptions/xxxxxxxxxx/resourceGroups/ss-sbox-00-rg/providers/Microsoft.ContainerService/managedClusters/ss-sbox-00-aks"
      ~ kubernetes_version                  = "1.24" -> "1.25"
        name                                = "ss-sbox-00-aks"
        tags                                = {
            "application"  = "core"
            "builtFrom"    = "hmcts/aks-sds-deploy"
            "businessArea" = "Cross-Cutting"
            "criticality"  = "Low"
            "environment"  = "sandbox"
        }
        ...
}

  # module.kubernetes["00"].azurerm_role_assignment.node_infrastructure_update_scale_set must be replaced
-/+ resource "azurerm_role_assignment" "node_infrastructure_update_scale_set" {
      ~ id                               = "xxxxxxxxxxx" -> (known after apply)
      ~ name                             = "xxxxxxxxxxxxx" -> (known after apply)
      ~ principal_type                   = "ServicePrincipal" -> (known after apply)
      ~ role_definition_id               = "xxxxxxxxxxxxxx" -> (known after apply)
      ~ scope                            = "/subscriptions/xxxxxxxxx/resourceGroups/ss-sbox-00-aks-node-rg" -> (known after apply) # forces replacement
      + skip_service_principal_aad_check = (known after apply)
        # (2 unchanged attributes hidden)
    }
``` 

From what I have seen, any changes made to the cluster configuration causes this issue. 

The data source has to be re-read because of the update to the cluster where the Resource Group "could" change, which makes the `scope` value for `module.kubernetes["00"].azurerm_role_assignment.node_infrastructure_update_scale_set` `known after apply` and that forces terraform to replace the assignment even though the scope hasn't changed.

Output with fix: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=306118&view=logs&j=ae32586c-a9fb-5009-45b6-4375cbbc84da&t=1678ad72-e1ed-5f3a-9d5f-fd1340e855d2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
