### PR TITLE
Add description to ASO role assignment

### DIFF
--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -245,10 +245,12 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 }
 
 # Azure Service Operator federated identity credential and role assignment
-
+resource "random_uuid" "aso_role_assignment_name" {
+  keepers = var.cluster_number
+}
 resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
-  name                 = "aks-${var.environment}-${var.cluster_number}-aso"
+  name                 = var.random_uuid.aso_role_assignment_name
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -248,6 +248,7 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 
 resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
+  name                 = "aks-${var.environment}-${var.cluster_number}-aso"
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -245,12 +245,9 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 }
 
 # Azure Service Operator federated identity credential and role assignment
-resource "random_uuid" "aso_role_assignment_name" {
-  keepers = var.cluster_number
-}
 resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
-  name                 = var.random_uuid.aso_role_assignment_name
+  description          = "Service operator role asssignment for ${var.environment}-${var.cluster_number}"
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12611

This change:
- Adds a description attribute to the role_assignment resource for ASO, to allow two clusters to manage the resource by including the cluster number in the name.


Failing build example: https://dev.azure.com/hmcts/CNP/_build/results?buildId=345707&view=logs&j=ae32586c-a9fb-5009-45b6-4375cbbc84da&t=6bfac74f-3a8d-5161-9f74-e350fd8357c8


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
