### PR TITLE
Dtspo 12611 remove aso role assignment

### DIFF
--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -245,11 +245,12 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 }
 
 # Azure Service Operator federated identity credential and role assignment
-
+resource "random_uuid" "aso_name" {
+}
 resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
+  name                 = var.random_uuid.aso_name.result
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
-  description          = "ASO role assignment for ${var.cluster_number} ${var.environment} cluster."
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id
 }

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -244,17 +244,6 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 
 }
 
-# Azure Service Operator federated identity credential and role assignment
-resource "random_uuid" "aso_name" {
-}
-resource "azurerm_role_assignment" "service_operator" {
-  count                = var.service_operator_settings_enabled ? 1 : 0
-  name                 = random_uuid.aso_name.result
-  principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
-  role_definition_name = "Contributor"
-  scope                = data.azurerm_subscription.subscription.id
-}
-
 resource "azapi_resource" "service_operator_credential" {
   count                     = var.service_operator_settings_enabled ? 1 : 0
   schema_validation_enabled = false

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -249,7 +249,7 @@ resource "random_uuid" "aso_name" {
 }
 resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
-  name                 = var.random_uuid.aso_name.result
+  name                 = random_uuid.aso_name.result
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -249,6 +249,7 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
+  description          = "ASO role assignment for ${var.cluster_number} ${var.environment} cluster."
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id
 }


### PR DESCRIPTION
This change:
- Removes ASO role assignment from the module so it can be managed more closely by deploy pipelines.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
