### PR TITLE
Give AKS permissions on disk rg in all environments

### DIFF
--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -190,7 +190,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
 }
 
 resource "azurerm_role_assignment" "disks_resource_group_role_assignment" {
-  count                = var.ptl_cluster ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   scope                = var.disks_resource_group_id
   role_definition_name = "Virtual Machine Contributor"


### PR DESCRIPTION
I need this for kubecost PoC but it seems silly to always create the disk rg but only permission it in PTL....