### PR TITLE
Use dedicated resource type for log analytics destination

### DIFF
--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -191,10 +191,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_setting" {
-  name                       = "DiagLogAnalytics"
-  count                      = var.monitor_diagnostic_setting ? 1 : 0
-  target_resource_id         = azurerm_kubernetes_cluster.kubernetes_cluster.id
-  log_analytics_workspace_id = var.log_workspace_id
+  name                           = "DiagLogAnalytics"
+  count                          = var.monitor_diagnostic_setting ? 1 : 0
+  target_resource_id             = azurerm_kubernetes_cluster.kubernetes_cluster.id
+  log_analytics_workspace_id     = var.log_workspace_id
+  log_analytics_destination_type = "Dedicated"
 
   log {
     category = "kube-apiserver"


### PR DESCRIPTION
### Change description ###

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting

> Possible values are AzureDiagnostics and Dedicated. When set to Dedicated, logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.

`AzureDiagnostics` table isn't recommended and doesn't allow you to do any transformation / filtering on incoming logs.
Much easier to have finer grained tables that also support new features such as `Basic` logs