### PR TITLE
Split diagnostics out

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -32,6 +32,14 @@ variable "monitor_diagnostic_setting" {
   default = true
 }
 
+variable "kube_audit_admin_logs_enabled" {
+  default = false
+}
+
+variable "monitor_diagnostic_setting_metrics" {
+  default = false
+}
+
 variable "sku_tier" {
   default     = "Free"
   description = "Free or Paid (which includes the uptime SLA)"

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -24,6 +24,14 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
   enabled_log {
     category = "kube-scheduler"
   }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "metrics_diagnostic_setting" {
+  name                           = "Metrics"
+  count                          = var.monitor_diagnostic_setting_metrics ? 1 : 0
+  target_resource_id             = azurerm_kubernetes_cluster.kubernetes_cluster.id
+  log_analytics_workspace_id     = var.log_workspace_id
+  log_analytics_destination_type = "Dedicated"
 
   metric {
     category = "AllMetrics"
@@ -31,21 +39,21 @@ resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_set
 }
 
 locals {
-  businessArea = var.project == "ss" ? "sds": var.project
+  businessArea = var.project == "ss" ? "sds" : var.project
 }
 
 data "azurerm_storage_account" "diagnostics" {
-  count = var.monitor_diagnostic_setting ? (var.environment == "prod" ? 1 : 0) : 0
+  count = var.kube_audit_admin_logs_enabled ? 1 : 0
 
   name                = "hmcts${local.businessArea}diag${var.environment}"
   resource_group_name = "lz-${var.environment}-rg"
 }
 
 resource "azurerm_monitor_diagnostic_setting" "kubernetes_cluster_diagnostic_setting_sa" {
-  name                           = "aks-storage"
-  count                          = var.monitor_diagnostic_setting ? (var.environment == "prod" ? 1 : 0) : 0
-  target_resource_id             = azurerm_kubernetes_cluster.kubernetes_cluster.id
-  storage_account_id             = data.azurerm_storage_account.diagnostics[0].id
+  name               = "aks-storage"
+  count              = var.kube_audit_admin_logs_enabled ? 1 : 0
+  target_resource_id = azurerm_kubernetes_cluster.kubernetes_cluster.id
+  storage_account_id = data.azurerm_storage_account.diagnostics[0].id
 
   enabled_log {
     category = "kube-audit-admin"


### PR DESCRIPTION
see https://github.com/hmcts/aks-cft-deploy/pull/571

This allows a bit more fine-tuning.

The plan is to still leave most things on in prod for now, but we might want to leave prod with just kube-audit-admin and maybe metrics later