### PR TITLE
Set OS SKU to Azure Linux based on Node Pool Name

### DIFF
--- a/10-kubernetes-inputs.tf
+++ b/10-kubernetes-inputs.tf
@@ -97,11 +97,6 @@ variable "azure_policy_enabled" {
   default     = false
 }
 
-variable "os_sku" {
-  description = "Use this OS SKU if the the OS Type for the Node Pool is specified as Linux"
-  default     = "Ubuntu"
-}
-
 variable "node_os_maintenance_window_config" {
   type = object({
     frequency   = optional(string, "Weekly")

--- a/12-kubernetes-cluster.tf
+++ b/12-kubernetes-cluster.tf
@@ -183,8 +183,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_node_pools" {
   max_count             = each.value.max_count
   max_pods              = lookup(each.value, "max_pods", "30")
   os_type               = lookup(each.value, "os_type", "Linux")
-  # A temporary change to set the os_sku as "AzureLinux" for sbox environments only
-  os_sku                = var.environment == "sbox" && lookup(each.value, "os_type", "Linux") == "Linux" ? var.os_sku : null
+  # A temporary change to set the os_sku as "AzureLinux" for the new azurelinux node pool only
+  os_sku                = each.value.name == "azurelinux" ? try(each.value.os_sku, "AzureLinux") : null
   os_disk_type          = "Ephemeral"
   eviction_policy       = each.value.name == "spotinstance" ? try(each.value.eviction_policy, "Delete") : null
   node_taints           = each.value.node_taints


### PR DESCRIPTION
### [Jira link](https://tools.hmcts.net/jira/browse/DTSPO-18220)

### Set OS SKU to Azure Linux based on Node Pool Name

### Description

Sets the os_sku to AzureLinux for the new temporary node pool that is called Azure Linux. Also removes a variable reference which was the previous attempt/approach but didnt work.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
