### PR TITLE
DTSPO-19027 updating azapi version 1.15.0

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azapi = {
       source  = "Azure/azapi"
-      version = "2.0.0-beta"
+      version = "1.15.0"
     }
   }
 }

--- a/00-init.tf
+++ b/00-init.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azapi = {
       source  = "Azure/azapi"
-      version = "1.1.0"
+      version = "2.0.0-beta"
     }
   }
 }


### PR DESCRIPTION
### Jira link
[DTSPO-19027](https://tools.hmcts.net/jira/browse/DTSPO-19027)

### Change description

Updating azapi version so I am able to test deployment of kubernetes automatic cluster.
This change is needed for this [pr](https://github.com/hmcts/aks-sds-deploy/pull/637)

ran a test against this updated azapi version [here](https://github.com/hmcts/aks-sds-deploy/pull/639)
