### PR TITLE
DTSPO-19027 updating azapi to v2-beta

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azapi = {
       source  = "Azure/azapi"
-      version = "1.15.0"
+      version = "2.0.0-beta"
     }
   }
 }


### PR DESCRIPTION
### Jira link
[DTSPO-19027](https://tools.hmcts.net/jira/browse/DTSPO-19027)

### Change description

Upgrading azapi version to v2 beta to test auto cluster deploy
