### PR TITLE
DTSPO 22075 - move azapi resource to use to use federated identity

### DIFF
--- a/service-operator.tf
+++ b/service-operator.tf
@@ -1,17 +1,8 @@
-resource "azapi_resource" "service_operator_credential" {
-  schema_validation_enabled = false
+resource "azurerm_federated_identity_credential" "service_operator_credential" {
   name                      = "${var.project}-${var.environment}-${var.cluster_number}-${var.service_shortname}"
+  resource_group_name       = var.resource_group_name
+  issuer                    = azurerm_kubernetes_cluster.kubernetes_cluster.oidc_issuer_url
+  audience                  = ["api://AzureADTokenExchange"]
   parent_id                 = data.azurerm_user_assigned_identity.aks.id
-  type                      = "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2022-01-31-preview"
-  location                  = var.location
-  body = jsonencode({
-    properties = {
-      issuer    = azurerm_kubernetes_cluster.kubernetes_cluster.oidc_issuer_url
-      subject   = "system:serviceaccount:azureserviceoperator-system:azureserviceoperator-default"
-      audiences = ["api://AzureADTokenExchange"]
-    }
-  })
-  lifecycle {
-    ignore_changes = [location]
-  }
+  subject                   = "system:serviceaccount:azureserviceoperator-system:azureserviceoperator-default"
 }


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-22075](https://tools.hmcts.net/jira/browse/DTSPO-22075)

### Change description

Remove the azapi resource in the Kubernetes module ASO file as it is giving a 409 error response. Change to use Terraform federated credentials identity instead.


- [ ] Bug fix (non-breaking change which fixes an issue)a
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested on AKS-CFT-SBOX 01 cluster by doing a redeployment 

https://github.com/hmcts/aks-cft-deploy/pull/694/files

### Issues Found

   with module.kubernetes["01"].azapi_resource.service_operator_credential,
│   on .terraform/modules/kubernetes/service-operator.tf line 1, in resource "azapi_resource" "service_operator_credential":
│    1: resource "azapi_resource" "service_operator_credential" {
│ 
│ creating/updating Resource: (ResourceId
│ "/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-demo-mi/federatedIdentityCredentials/ss-demo-01-aks"
│ / Api Version "2022-01-31-preview"): PUT
│ https://management.azure.com/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-demo-mi/federatedIdentityCredentials/ss-demo-01-aks
│ --------------------------------------------------------------------------------
│ RESPONSE 409: 409 Conflict
│ ERROR CODE:
│ ConcurrentFederatedIdentityCredentialsWritesForSingleManagedIdentity
│ --------------------------------------------------------------------------------
│ {
│   "error": {
│     "code": "ConcurrentFederatedIdentityCredentialsWritesForSingleManagedIdentity",
│     "message": "Too many Federated Identity Credentials are written concurrently for the managed identity '/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourcegroups/genesis-rg/providers/microsoft.managedidentity/userassignedidentities/aks-demo-mi'. Concurrent Federated Identity Credentials writes under the same managed identity are not supported."
│   }
│ }  


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Deployment Steps

Please provide the steps required to deploy these changes to Azure.

https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=776527&view=logs&j=16ddf0d5-1e10-5fec-9c2d-4314e7f70b81&t=bb8408c3-ac01-5dd5-e3b0-5cafd1c7bafb&s=ae6021a5-b5db-54db-784c-3e937fb7ded4

https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=777092&view=logs&j=55293921-7148-5fb3-9197-b501b11bbea1&t=a691e737-0590-5e0f-27ef-c34c42a5f6e5


## Additional Information

Please add any other information that is important to this PR, such as screenshots, logs, or links to other related PRs.

https://github.com/hashicorp/terraform-provider-azurerm/pull/20003

