### PR TITLE
DTSPO-27222 - Set azure_policy_enabled default to true

### DIFF
--- a/10-kubernetes-inputs.tf
+++ b/10-kubernetes-inputs.tf
@@ -126,7 +126,7 @@ variable "cost_analysis_enabled" {
 
 variable "azure_policy_enabled" {
   description = "Enable the Azure Policy addon"
-  default     = false
+  default     = true
 }
 
 variable "node_os_maintenance_window_config" {


### PR DESCRIPTION
### Jira link
[DTSPO-27222](https://tools.hmcts.net/jira/browse/DTSPO-27222)

### Change description
Set azure_policy_enabled default to true

### Testing done
Ran branch changes on SDS and CFT Sandbox.
Successfully enabled azure policy add-on (sbox):
<img width="1140" height="430" alt="image" src="https://github.com/user-attachments/assets/251c635e-6048-484b-929f-1022704e0f22" />


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
